### PR TITLE
Add specgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
- - "1.16.x"
+ - "1.18.x"
 
 sudo: required
 dist: trusty

--- a/specgen/specgen.go
+++ b/specgen/specgen.go
@@ -1,0 +1,518 @@
+// Package specgen provides a utility for generating utls.ClientHelloSpec.
+package specgen
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+
+	tls "github.com/getlantern/utls"
+)
+
+const (
+	// When we print byte slices, we print this many bytes per line.
+	bytesPerLine = 12
+
+	tlsRecordHeaderLen = 5
+)
+
+// WriteHelloSpec writes a utls.ClientHelloSpec corresponding to the input ClientHello.
+//
+// packagePrefix can be used to control the package qualifier on utls definitions. For example, if
+// packagePrefix is provided as "tls", then cipher suites will be specified like
+// "tls.TLS_AES_128_GCM_SHA256" in the output code. If packagePrefix is the empty string, then no
+// qualifier will be used. The example cipher suite would be printed as "TLS_AES_128_GCM_SHA256".
+func WriteHelloSpec(w io.Writer, clientHello []byte, packagePrefix string) error {
+	prefix := ""
+	if packagePrefix != "" {
+		prefix = packagePrefix + "."
+	}
+
+	helloSpec, err := tls.FingerprintClientHello(clientHello[tlsRecordHeaderLen:])
+	if err != nil {
+		return fmt.Errorf("failed to fingerprint hello: %w", err)
+	}
+
+	fmt.Fprintf(w, "%sClientHelloSpec{\n", prefix)
+
+	minVersionStr, ok := versions[helloSpec.TLSVersMin]
+	if !ok {
+		return fmt.Errorf("unrecognized min version: %#x", helloSpec.TLSVersMin)
+	}
+	maxVersionStr, ok := versions[helloSpec.TLSVersMax]
+	if !ok {
+		return fmt.Errorf("unrecognized max version: %#x", helloSpec.TLSVersMax)
+	}
+	fmt.Fprintf(w, "\tTLSVersMin: %s%s,\n", prefix, minVersionStr)
+	fmt.Fprintf(w, "\tTLSVersMax: %s%s,\n", prefix, maxVersionStr)
+
+	fmt.Fprintf(w, "\tCipherSuites: []uint16{\n")
+	for _, suite := range helloSpec.CipherSuites {
+		suiteStr, ok := cipherSuites[suite]
+		if !ok {
+			suiteStr = fmt.Sprintf("%#x", suite)
+		} else {
+			suiteStr = fmt.Sprintf("%s%s", prefix, suiteStr)
+		}
+		fmt.Fprintf(w, "\t\t%s,\n", suiteStr)
+	}
+	fmt.Fprintf(w, "\t},\n")
+
+	fmt.Fprintf(w, "\tCompressionMethods: []uint8{\n")
+	for _, method := range helloSpec.CompressionMethods {
+		fmt.Fprintf(w, "\t\t%#x,", method)
+		if method == 0 {
+			fmt.Fprintf(w, " // no compression")
+		}
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintf(w, "\t},\n")
+
+	fmt.Fprintf(w, "\tExtensions: []%sTLSExtension{\n", prefix)
+	for _, ext := range helloSpec.Extensions {
+		if err := writeExtension(w, ext, 2, prefix); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(w, "\t},\n")
+
+	fmt.Fprintf(w, "}\n")
+
+	return nil
+}
+
+func writeExtension(w io.Writer, e tls.TLSExtension, tabs int, prefix string) error {
+	tabStr := ""
+	for i := 0; i < tabs; i++ {
+		tabStr += "\t"
+	}
+
+	switch ext := e.(type) {
+	case *tls.ALPNExtension:
+		fmt.Fprintf(w, "%s&%sALPNExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tAlpnProtocols: []string{\n", tabStr)
+
+		for _, p := range ext.AlpnProtocols {
+			fmt.Fprintf(w, "%s\t\t\"%s\",\n", tabStr, p)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.CookieExtension:
+		// The cookie extension should not appear in the initial ClientHello:
+		// https://datatracker.ietf.org/doc/html/rfc8446#section-4.2.2
+		return errors.New("unexpected cookie extension")
+
+	case *tls.FakeALPSExtension:
+		fmt.Fprintf(w, "%s&%sFakeALPSExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tSupportedProtocols: []string{\n", tabStr)
+
+		for _, p := range ext.SupportedProtocols {
+			fmt.Fprintf(w, "%s\t\t\"%s\",\n", tabStr, p)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.FakeChannelIDExtension:
+		fmt.Fprintf(w, "%s&%sFakeChannelIDExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tOldExtensionID: %t,\n", tabStr, ext.OldExtensionID)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.FakeRecordSizeLimitExtension:
+		fmt.Fprintf(w, "%s&%sFakeRecordSizeLimitExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tLimit: %#x,\n", tabStr, ext.Limit)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.FakeTokenBindingExtension:
+		fmt.Fprintf(w, "%s&%sFakeTokenBindingExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tMajorVersion: %d,\n", tabStr, ext.MinorVersion)
+		fmt.Fprintf(w, "%s\tMinorVersion: %d,\n", tabStr, ext.MajorVersion)
+		fmt.Fprintf(w, "%s\tKeyParameters: []uint8{\n", tabStr)
+
+		for _, kp := range ext.KeyParameters {
+			fmt.Fprintf(w, "%s\t\t%d,\n", tabStr, kp)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.FakeDelegatedCredentialsExtension:
+		fmt.Fprintf(w, "%s&%sFakeDelegatedCredentialsExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tSupportedSignatureAlgorithms: []%sSignatureScheme{\n", tabStr, prefix)
+
+		for _, alg := range ext.SupportedSignatureAlgorithms {
+			algStr, ok := signatureAlgorithms[alg]
+			if ok {
+				algStr = fmt.Sprintf("%s%s", prefix, algStr)
+			} else {
+				algStr = fmt.Sprintf("%d", alg)
+			}
+
+			fmt.Fprintf(w, "%s\t\t%s,\n", tabStr, algStr)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.GenericExtension:
+		fmt.Fprintf(w, "%s&%sGenericExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tId: %d,\n", tabStr, ext.Id)
+		fmt.Fprintf(w, "%s\tData: []byte{\n", tabStr)
+
+		printByteSlice(w, ext.Data, tabs+2)
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.KeyShareExtension:
+		fmt.Fprintf(w, "%s&%sKeyShareExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tKeyShares: []%sKeyShare{\n", tabStr, prefix)
+
+		for _, ks := range ext.KeyShares {
+			groupStr, ok := curves[ks.Group]
+			if ok {
+				groupStr = fmt.Sprintf("%s%s", prefix, groupStr)
+			} else {
+				groupStr = fmt.Sprintf("%d", ks.Group)
+			}
+
+			fmt.Fprintf(w, "%s\t\t{\n", tabStr)
+			fmt.Fprintf(w, "%s\t\t\tGroup: %s,\n", tabStr, groupStr)
+
+			if ks.Data != nil {
+				fmt.Fprintf(w, "%s\t\t\tData: []byte{\n", tabStr)
+				printByteSlice(w, ks.Data, tabs+4)
+				fmt.Fprintf(w, "%s\t\t\t},\n", tabStr)
+			}
+
+			fmt.Fprintf(w, "%s\t\t},\n", tabStr)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.NPNExtension:
+		fmt.Fprintf(w, "%s&%sNPNExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tNextProtos: []string{\n", tabStr)
+
+		for _, proto := range ext.NextProtos {
+			fmt.Fprintf(w, "%s\t\t%s,\n", tabStr, proto)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.PSKKeyExchangeModesExtension:
+		fmt.Fprintf(w, "%s&%sPSKKeyExchangeModesExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tModes: []uint8{\n", tabStr)
+
+		for _, mode := range ext.Modes {
+			modeStr, ok := pskModes[mode]
+			if ok {
+				modeStr = fmt.Sprintf("%s%s", prefix, modeStr)
+			} else {
+				modeStr = fmt.Sprintf("%#x", mode)
+			}
+
+			fmt.Fprintf(w, "%s\t\t%s,\n", tabStr, modeStr)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.RenegotiationInfoExtension:
+		fmt.Fprintf(w, "%s&%sRenegotiationInfoExtension{\n", tabStr, prefix)
+
+		renStr, ok := renogotiations[ext.Renegotiation]
+		if ok {
+			renStr = fmt.Sprintf("%s%s", prefix, renStr)
+		} else {
+			renStr = fmt.Sprintf("%d", ext.Renegotiation)
+		}
+
+		fmt.Fprintf(w, "%s\tRenegotiation: %s,\n", tabStr, renStr)
+
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.SCTExtension:
+		fmt.Fprintf(w, "%s&%sSCTExtension{},\n", tabStr, prefix)
+
+	case *tls.SNIExtension:
+		fmt.Fprintf(w, "%s&%sSNIExtension{},\n", tabStr, prefix)
+
+	case *tls.SessionTicketExtension:
+		fmt.Fprintf(w, "%s&%sSessionTicketExtension{},\n", tabStr, prefix)
+
+	case *tls.SignatureAlgorithmsExtension:
+		fmt.Fprintf(w, "%s&%sSignatureAlgorithmsExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tSupportedSignatureAlgorithms: []%sSignatureScheme{\n", tabStr, prefix)
+
+		for _, alg := range ext.SupportedSignatureAlgorithms {
+			algStr, ok := signatureAlgorithms[alg]
+			if ok {
+				algStr = fmt.Sprintf("%s%s", prefix, algStr)
+			} else {
+				algStr = fmt.Sprintf("%d", alg)
+			}
+
+			fmt.Fprintf(w, "%s\t\t%s,\n", tabStr, algStr)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.StatusRequestExtension:
+		fmt.Fprintf(w, "%s&%sStatusRequestExtension{},\n", tabStr, prefix)
+
+	case *tls.SupportedCurvesExtension:
+		fmt.Fprintf(w, "%s&%sSupportedCurvesExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tCurves: []%sCurveID{\n", tabStr, prefix)
+
+		for _, curve := range ext.Curves {
+			curveStr, ok := curves[curve]
+			if ok {
+				curveStr = fmt.Sprintf("%s%s", prefix, curveStr)
+			} else {
+				curveStr = fmt.Sprintf("%d", curve)
+			}
+
+			fmt.Fprintf(w, "%s\t\t%s,\n", tabStr, curveStr)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.SupportedPointsExtension:
+		fmt.Fprintf(w, "%s&%sSupportedPointsExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tSupportedPoints: []uint8{\n", tabStr)
+
+		for _, point := range ext.SupportedPoints {
+			fmt.Fprintf(w, "%s\t\t%#x,", tabStr, point)
+
+			if point == 0 {
+				fmt.Fprintf(w, " // uncompressed")
+			}
+			fmt.Fprintln(w)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.SupportedVersionsExtension:
+		fmt.Fprintf(w, "%s&%sSupportedVersionsExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tVersions: []uint16{\n", tabStr)
+
+		for _, version := range ext.Versions {
+			versionStr, ok := versions[version]
+			if ok {
+				versionStr = fmt.Sprintf("%s%s", prefix, versionStr)
+			} else {
+				versionStr = fmt.Sprintf("%#x", version)
+			}
+
+			fmt.Fprintf(w, "%s\t\t%s,\n", tabStr, versionStr)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.UtlsCompressCertExtension:
+		fmt.Fprintf(w, "%s&%sUtlsCompressCertExtension{\n", tabStr, prefix)
+		fmt.Fprintf(w, "%s\tAlgorithms: []%sCertCompressionAlgo{\n", tabStr, prefix)
+
+		for _, alg := range ext.Algorithms {
+			algStr, ok := certCompressionAlgs[alg]
+			if ok {
+				algStr = fmt.Sprintf("%s%s", prefix, algStr)
+			} else {
+				algStr = fmt.Sprintf("%d", alg)
+			}
+
+			fmt.Fprintf(w, "%s\t\t%s,\n", tabStr, algStr)
+		}
+
+		fmt.Fprintf(w, "%s\t},\n", tabStr)
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	case *tls.UtlsExtendedMasterSecretExtension:
+		fmt.Fprintf(w, "%s&%sUtlsExtendedMasterSecretExtension{},\n", tabStr, prefix)
+
+	case *tls.UtlsGREASEExtension:
+		fmt.Fprintf(w, "%s&%sUtlsGREASEExtension{},\n", tabStr, prefix)
+
+	case *tls.UtlsPaddingExtension:
+		fmt.Fprintf(w, "%s&%sUtlsPaddingExtension{\n", tabStr, prefix)
+
+		if ext.PaddingLen != 0 {
+			fmt.Fprintf(w, "%s\tPaddingLen: %d\n", tabStr, ext.PaddingLen)
+		}
+		if ext.WillPad != false {
+			fmt.Fprintf(w, "%s\tWillPad: %t\n", tabStr, ext.WillPad)
+		}
+
+		if ext.GetPaddingLen != nil {
+			if sameFunc(ext.GetPaddingLen, tls.BoringPaddingStyle) {
+				fmt.Fprintf(w, "%s\tGetPaddingLen: %sBoringPaddingStyle,\n", tabStr, prefix)
+			} else {
+				return errors.New("unrecognized func in UtlsPaddingExtension.GetPaddingLen")
+			}
+		}
+
+		fmt.Fprintf(w, "%s},\n", tabStr)
+
+	default:
+		return fmt.Errorf("unrecognized extension %T", e)
+	}
+
+	return nil
+}
+
+func printByteSlice(w io.Writer, b []byte, tabs int) {
+	tabStr := ""
+	for i := 0; i < tabs; i++ {
+		tabStr += "\t"
+	}
+
+	for i, bite := range b {
+		fmt.Fprintf(w, "%s%d,", tabStr, bite)
+		if i != 0 && i%bytesPerLine == 0 {
+			fmt.Fprintf(w, "\n")
+		} else {
+			fmt.Fprintf(w, " ")
+		}
+	}
+
+	if len(b)%bytesPerLine != 0 {
+		fmt.Fprintln(w)
+	}
+}
+
+// Performs an identity check (*not* an equality check) on the two input functions. Returns true iff
+// the two functions have the same underlying code pointer. This relies on implementation details of
+// standard Go and is therefore a bit fragile. It should be okay for our use case though.
+func sameFunc(f1, f2 any) bool {
+	f1Val := reflect.ValueOf(f1)
+	f2Val := reflect.ValueOf(f2)
+
+	return f1Val.Pointer() == f2Val.Pointer()
+}
+
+var (
+	versions = map[uint16]string{
+		tls.VersionSSL30: "VersionSSL30",
+		tls.VersionTLS10: "VersionTLS10",
+		tls.VersionTLS11: "VersionTLS11",
+		tls.VersionTLS12: "VersionTLS12",
+		tls.VersionTLS13: "VersionTLS13",
+
+		tls.GREASE_PLACEHOLDER: "GREASE_PLACEHOLDER",
+	}
+
+	cipherSuites = map[uint16]string{
+		// TLS 1.0 - 1.2 cipher suites.
+		tls.TLS_RSA_WITH_RC4_128_SHA:                "TLS_RSA_WITH_RC4_128_SHA",
+		tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA:           "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA:            "TLS_RSA_WITH_AES_128_CBC_SHA",
+		tls.TLS_RSA_WITH_AES_256_CBC_SHA:            "TLS_RSA_WITH_AES_256_CBC_SHA",
+		tls.TLS_RSA_WITH_AES_128_CBC_SHA256:         "TLS_RSA_WITH_AES_128_CBC_SHA256",
+		tls.TLS_RSA_WITH_AES_128_GCM_SHA256:         "TLS_RSA_WITH_AES_128_GCM_SHA256",
+		tls.TLS_RSA_WITH_AES_256_GCM_SHA384:         "TLS_RSA_WITH_AES_256_GCM_SHA384",
+		tls.TLS_ECDHE_ECDSA_WITH_RC4_128_SHA:        "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:    "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:    "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+		tls.TLS_ECDHE_RSA_WITH_RC4_128_SHA:          "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+		tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA:     "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:      "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:      "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256: "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256:   "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:   "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:   "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305:    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305:  "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+
+		// TLS 1.3 cipher suites.
+		tls.TLS_AES_128_GCM_SHA256:       "TLS_AES_128_GCM_SHA256",
+		tls.TLS_AES_256_GCM_SHA384:       "TLS_AES_256_GCM_SHA384",
+		tls.TLS_CHACHA20_POLY1305_SHA256: "TLS_CHACHA20_POLY1305_SHA256",
+
+		// TLS_FALLBACK_SCSV isn't a standard cipher suite but an indicator
+		// that the client is doing version fallback. See RFC 7507.
+		tls.TLS_FALLBACK_SCSV: "TLS_FALLBACK_SCSV",
+
+		tls.OLD_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:   "OLD_TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+		tls.OLD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256: "OLD_TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+
+		tls.DISABLED_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384: "DISABLED_TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+		tls.DISABLED_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384:   "DISABLED_TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+		tls.DISABLED_TLS_RSA_WITH_AES_256_CBC_SHA256:         "DISABLED_TLS_RSA_WITH_AES_256_CBC_SHA256",
+
+		tls.FAKE_OLD_TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256: "FAKE_OLD_TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+		tls.FAKE_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256:           "FAKE_TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+
+		tls.FAKE_TLS_DHE_RSA_WITH_AES_128_CBC_SHA:    "FAKE_TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+		tls.FAKE_TLS_DHE_RSA_WITH_AES_256_CBC_SHA:    "FAKE_TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+		tls.FAKE_TLS_RSA_WITH_RC4_128_MD5:            "FAKE_TLS_RSA_WITH_RC4_128_MD5",
+		tls.FAKE_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384: "FAKE_TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+		tls.FAKE_TLS_DHE_DSS_WITH_AES_128_CBC_SHA:    "FAKE_TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+		tls.FAKE_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256: "FAKE_TLS_DHE_RSA_WITH_AES_256_CBC_SHA256",
+		tls.FAKE_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256: "FAKE_TLS_DHE_RSA_WITH_AES_128_CBC_SHA256",
+		tls.FAKE_TLS_EMPTY_RENEGOTIATION_INFO_SCSV:   "FAKE_TLS_EMPTY_RENEGOTIATION_INFO_SCSV",
+
+		tls.FAKE_TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA: "FAKE_TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+
+		tls.GREASE_PLACEHOLDER: "GREASE_PLACEHOLDER",
+	}
+
+	pskModes = map[uint8]string{
+		tls.PskModePlain: "PskModePlain",
+		tls.PskModeDHE:   "PskModeDHE",
+	}
+
+	renogotiations = map[tls.RenegotiationSupport]string{
+		tls.RenegotiateNever:          "RenegotiateNever",
+		tls.RenegotiateOnceAsClient:   "RenegotiateOnceAsClient",
+		tls.RenegotiateFreelyAsClient: "RenegotiateFreelyAsClient",
+	}
+
+	signatureAlgorithms = map[tls.SignatureScheme]string{
+		// RSASSA-PKCS1-v1_5 algorithms.
+		tls.PKCS1WithSHA256: "PKCS1WithSHA256",
+		tls.PKCS1WithSHA384: "PKCS1WithSHA384",
+		tls.PKCS1WithSHA512: "PKCS1WithSHA512",
+
+		// RSASSA-PSS algorithms with public key OID rsaEncryption.
+		tls.PSSWithSHA256: "PSSWithSHA256",
+		tls.PSSWithSHA384: "PSSWithSHA384",
+		tls.PSSWithSHA512: "PSSWithSHA512",
+
+		// ECDSA algorithms. Only constrained to a specific curve in TLS 1.3.
+		tls.ECDSAWithP256AndSHA256: "ECDSAWithP256AndSHA256",
+		tls.ECDSAWithP384AndSHA384: "ECDSAWithP384AndSHA384",
+		tls.ECDSAWithP521AndSHA512: "ECDSAWithP521AndSHA512",
+
+		// Legacy signature and hash algorithms for TLS 1.2.
+		tls.PKCS1WithSHA1: "PKCS1WithSHA1",
+		tls.ECDSAWithSHA1: "ECDSAWithSHA1",
+	}
+
+	curves = map[tls.CurveID]string{
+		tls.CurveP256: "CurveP256",
+		tls.CurveP384: "CurveP384",
+		tls.CurveP521: "CurveP521",
+		tls.X25519:    "X25519",
+
+		tls.GREASE_PLACEHOLDER: "GREASE_PLACEHOLDER",
+	}
+
+	certCompressionAlgs = map[tls.CertCompressionAlgo]string{
+		tls.CertCompressionZlib:   "CertCompressionZlib",
+		tls.CertCompressionBrotli: "CertCompressionBrotli",
+		tls.CertCompressionZstd:   "CertCompressionZstd",
+	}
+)

--- a/specgen/specgen/hellocap/example_test.go
+++ b/specgen/specgen/hellocap/example_test.go
@@ -1,0 +1,100 @@
+package hellocap_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/getlantern/utls/specgen/specgen/hellocap"
+)
+
+func handler(w http.ResponseWriter, req *http.Request) {
+	hello, err := hellocap.FromRequest(req)
+	if err != nil {
+		log.Printf("error capturing hello: %v", err)
+		return
+	}
+
+	// Respond to the client with their own captured ClientHello.
+	fmt.Fprintf(w, "%#x\n", hello)
+}
+
+func Example() {
+	serverCert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	if err != nil {
+		log.Panic(err)
+	}
+
+	s, err := hellocap.NewServer(http.HandlerFunc(handler), "localhost:0", serverCert)
+	if err != nil {
+		log.Panic(err)
+	}
+	defer s.Close()
+
+	go s.ListenAndServe()
+
+	c := http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+
+	resp, err := c.Get("https://" + s.Addr().String())
+	if err != nil {
+		log.Panic(err)
+	}
+	defer resp.Body.Close()
+
+	echoedHello, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	// Print the first 3 bytes of the record header.
+	// (This will be 8 characters: the 2-byte prefix + 3 * 2 characters per byte).
+	fmt.Println(string(echoedHello)[:8])
+
+	// Output: 0x160301
+}
+
+// A self-signed TLS key pair valid until 2032.
+var (
+	certPEM = `-----BEGIN CERTIFICATE-----
+MIICyDCCAjGgAwIBAgIUTAmBa1Dd9Hz0pRjoYzi93d+e9GkwDQYJKoZIhvcNAQEL
+BQAwcDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMREwDwYDVQQHDAhTb21lQ2l0
+eTESMBAGA1UECgwJTXlDb21wYW55MRMwEQYDVQQLDApNeURpdmlzaW9uMRgwFgYD
+VQQDDA93d3cuY29tcGFueS5jb20wHhcNMjIxMTA2MjMyNDEzWhcNMzIxMTAzMjMy
+NDEzWjBwMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExETAPBgNVBAcMCFNvbWVD
+aXR5MRIwEAYDVQQKDAlNeUNvbXBhbnkxEzARBgNVBAsMCk15RGl2aXNpb24xGDAW
+BgNVBAMMD3d3dy5jb21wYW55LmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkC
+gYEAoWRAcyBPWAOEIBS7vJIdTKvdRGoY811RYTL1b78i68zIU87Hw03oSL2aw1ol
+gIcFWjupLA8nUI4I6n2ZXpc3tEmf45NPAQEh1V7kxf03CWimbmPw1DHTypYM/Wps
+af9xM+1+jP6ns/h1d8dO4UWdNbMf04+4k0vQtKCshGPniWMCAwEAAaNfMF0wCwYD
+VR0PBAQDAgRwMBMGA1UdJQQMMAoGCCsGAQUFBwMBMBoGA1UdEQQTMBGCCWxvY2Fs
+aG9zdIcEfwAAATAdBgNVHQ4EFgQUEosohEbGBpAeOSVjgf24dql8JlswDQYJKoZI
+hvcNAQELBQADgYEAGywH1HYIL0WaBhLcg5OoYfyWJ20OfTHxLvdMAoM6YVaui1fW
+/Lmf+BTWafx0FW/BLd/ZretaQmvBeUnATz6pZX+kMAZ0AY6Ya/usxpJL1re2W3o9
+nD7qdzdP4OLtYm5xTWOdZR/oj3lZzHNGZmCjs7P/VML4129my1OWAVfINCw=
+-----END CERTIFICATE-----`
+
+	keyPEM = `-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKFkQHMgT1gDhCAU
+u7ySHUyr3URqGPNdUWEy9W+/IuvMyFPOx8NN6Ei9msNaJYCHBVo7qSwPJ1COCOp9
+mV6XN7RJn+OTTwEBIdVe5MX9Nwlopm5j8NQx08qWDP1qbGn/cTPtfoz+p7P4dXfH
+TuFFnTWzH9OPuJNL0LSgrIRj54ljAgMBAAECgYBHqWgktngEsKr+Q7aIqKhx3u5E
+7oddqFX2PtZUZB5xbWCWNf7lbbZydh4+F80HIOzzgAJCGghu8GJtHI/5PFPy+ORH
+XZvU7eTqt35LM5uuSLisrD/laOPVnCPGrLfmX8U+d00ffwLsiNJ69bCAooia2gzA
+zMVOU9STzQVUdN8sIQJBANbY/vTK8uXDKlmA//eHzvuC5axa+Gmbz8a3z250rs17
+SXUZdIVauwyFWIoaCbZJCd7ow6WSy9WpasZKciXAYUcCQQDATg0+8xbakhLlN9V9
+FzHxNlkQJq6OrHfxNSIEANppI+xmoMlnKDQuoTrubEeKLienPzxzVLqtjPPoTthW
+ZsUFAkAk+Oa3HY27OGC7UlW6NSbLZXU8udLx6ZxR6CPMMEw8lDDJ8/13TWvO9cuM
+yHpPYjZOo+O3RJHLTQJQ6VLHaFnVAkEAs5xy/LeZQd4rLdIfYS135P5I4y/t2640
+fKKOucR+OrNlylkko2fGjULjwup5SxNez/PdJy8dCJnc+b4ii1iDbQJBAKNhQf+H
+s0gTmodJUZ9+7hF6c8D7js2UTc2r79D34nRE3yXmZDU2dJHT2KXbizBPET3OXmtN
+GGAzrM+tNzEmHDc=
+-----END PRIVATE KEY-----`
+)

--- a/specgen/specgen/hellocap/hellocap.go
+++ b/specgen/specgen/hellocap/hellocap.go
@@ -1,0 +1,57 @@
+// Package hellocap provides facilities for capturing TLS ClientHellos.
+package hellocap
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+)
+
+// Server is a TLS server used to capture incoming ClientHellos. This is built specifically for the
+// specgen use case. Performance is not prioritized and features are intentionally minimal.
+type Server struct {
+	s  http.Server
+	hl *handlerListener
+}
+
+// NewServer creates a new hello-capturing HTTP server. In the provided handler, use FromRequest to
+// obtain the TLS ClientHello provided by the client.
+func NewServer(handler http.Handler, addr string, cert tls.Certificate) (*Server, error) {
+	// handlerListener does the heavy lifting for us, connecting the TCP-level logic with the HTTP
+	// request contexts.
+	hl, err := newHandlerListener(addr, handler)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Server{
+		http.Server{
+			Handler: hl,
+			TLSConfig: &tls.Config{
+				Certificates: []tls.Certificate{cert},
+				// We disable session ticket support to prevent browsers from sending the pre-shared
+				// key extension; this extension is not supported by utls.FingerprintClientHello.
+				SessionTicketsDisabled: true,
+			},
+		},
+		hl,
+	}, nil
+}
+
+// Addr returns the network address this server listens on. Until ListenAndServe is called, behavior
+// is undefined for incoming connections to this address.
+func (s *Server) Addr() net.Addr {
+	return s.hl.Addr()
+}
+
+// ListenAndServe listens for incoming TCP connections and serves using the handler provided to
+// NewServer.
+func (s *Server) ListenAndServe() error {
+	return s.s.ServeTLS(s.hl, "", "")
+}
+
+// Close immediately closes the server, the underlying listener, and any outstanding connections.
+func (s *Server) Close() error {
+	s.hl.Close()
+	return s.s.Close()
+}

--- a/specgen/specgen/hellocap/listener.go
+++ b/specgen/specgen/hellocap/listener.go
@@ -1,0 +1,200 @@
+package hellocap
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+)
+
+const tlsRecordHeaderLen = 5
+
+type contextKey int
+
+// contextHelloKey is the context key for retrieving the ClientHello.
+const contextHelloKey contextKey = 0
+
+// FromRequest returns the TLS ClientHello sent by the remote. This request must have come through a
+// handler attached to the Server type in this package.
+func FromRequest(req *http.Request) ([]byte, error) {
+	hello, ok := req.Context().Value(contextHelloKey).(capturedHello)
+	if !ok {
+		return nil, errors.New("no attached ClientHello")
+	}
+	return hello.hello, hello.err
+}
+
+// attachHello is used to put a captured ClientHello on a http.Request context. This is how the
+// ClientHello, captured at the TCP level, is made available to users of this library.
+func attachHello(req *http.Request, hello capturedHello) *http.Request {
+	ctx := context.WithValue(req.Context(), contextHelloKey, hello)
+	return req.Clone(ctx)
+}
+
+// onHello is a callback invoked when a ClientHello is captured. Only one of hello or err will be
+// non-nil. This callback is not invoked for incomplete ClientHellos. In other words, err is non-nil
+// only if what has been read off the connection could not possibly constitute a ClientHello,
+// regardless of further data from the connection.
+type onHello func(hello []byte, err error)
+
+// capturingConn is a TCP connection and implements net.Conn. If a TLS ClientHello is sent by the
+// peer, capturingConn will invoke the provided onHello callback. This is the basic building block
+// by which we build a hello-capturing server.
+type capturingConn struct {
+	// Wraps a TCP connection.
+	net.Conn
+
+	helloRead bool
+	helloBuf  *bytes.Buffer
+	helloLock sync.Mutex // protects fields in this block
+
+	onHello onHello
+	onClose func()
+}
+
+func newCapturingConn(wrapped net.Conn, onHello onHello, onClose func()) *capturingConn {
+	return &capturingConn{
+		wrapped,
+		false,
+		new(bytes.Buffer),
+		sync.Mutex{},
+		onHello,
+		onClose,
+	}
+}
+
+func (c *capturingConn) Read(b []byte) (n int, err error) {
+	n, err = c.Conn.Read(b)
+	c.checkHello(b[:n])
+	return
+}
+
+func (c *capturingConn) checkHello(newBytes []byte) {
+	c.helloLock.Lock()
+	if !c.helloRead {
+		c.helloBuf.Write(newBytes)
+		if c.helloBuf.Len() >= tlsRecordHeaderLen {
+			helloLen, err := parseClientHelloHeader(c.helloBuf.Bytes()[:tlsRecordHeaderLen])
+			if err != nil {
+				c.onHello(nil, fmt.Errorf("failed to parse header: %w", err))
+				c.helloRead = true
+			}
+			if c.helloBuf.Len() >= helloLen {
+				c.onHello(c.helloBuf.Bytes()[:helloLen+tlsRecordHeaderLen], nil)
+				c.helloRead = true
+			}
+		}
+	}
+	c.helloLock.Unlock()
+}
+
+func (c *capturingConn) Close() error {
+	c.onClose()
+	return c.Conn.Close()
+}
+
+type capturedHello struct {
+	hello []byte
+	err   error
+}
+
+// handlerListener is used to listen for raw TCP connections as part of an HTTPS server. The TCP
+// connections are assumed to come from TLS clients. handlerListener captures the TLS ClientHello
+// (using capturingConn) and attaches it to the *http.Request context (using attachHello).
+//
+// Implements net.Listener and http.Handler.
+type handlerListener struct {
+	tcpListener net.Listener
+	handler     http.Handler
+
+	hellosByRemote map[string]capturedHello
+	sync.Mutex
+}
+
+func newHandlerListener(addr string, handler http.Handler) (*handlerListener, error) {
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	return &handlerListener{
+		l, handler, map[string]capturedHello{}, sync.Mutex{},
+	}, nil
+}
+
+func (hl *handlerListener) Addr() net.Addr {
+	return hl.tcpListener.Addr()
+}
+
+func (hl *handlerListener) Accept() (net.Conn, error) {
+	conn, err := hl.tcpListener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	onHello := func(hello []byte, err error) {
+		hl.Lock()
+		hl.hellosByRemote[conn.RemoteAddr().String()] = capturedHello{hello, err}
+		hl.Unlock()
+	}
+	onClose := func() {
+		hl.Lock()
+		delete(hl.hellosByRemote, conn.RemoteAddr().String())
+		hl.Unlock()
+	}
+
+	return newCapturingConn(conn, onHello, onClose), nil
+}
+
+func (hl *handlerListener) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	hl.Lock()
+	hello, ok := hl.hellosByRemote[req.RemoteAddr]
+	hl.Unlock()
+
+	if ok {
+		req = attachHello(req, hello)
+	}
+	hl.handler.ServeHTTP(rw, req)
+}
+
+func (hl *handlerListener) Close() error {
+	return hl.tcpListener.Close()
+}
+
+func parseClientHelloHeader(hdr []byte) (recordLen int, err error) {
+	const (
+		recordTypeChangeCipherSpec = 0x14
+		recordTypeAlert            = 0x15
+		recordTypeHandshake        = 0x16
+		recordTypeApplicationData  = 0x17
+
+		versionSSL30 = 0x0300
+		versionTLS13 = 0x0304
+	)
+
+	if len(hdr) < tlsRecordHeaderLen {
+		return 0, fmt.Errorf("header must be at least %d bytes", tlsRecordHeaderLen)
+	}
+
+	// Ensure this is a handshake record. Provide a specific error message when possible.
+	if hdr[0] == recordTypeAlert {
+		// n.b. We're unlikely to get a CCS or application data record out of order.
+		return 0, errors.New("bad record type, received alert record")
+	}
+	if hdr[0] < recordTypeChangeCipherSpec || hdr[0] > recordTypeApplicationData {
+		return 0, errors.New("not a TLS record")
+	}
+	if hdr[0] != recordTypeHandshake {
+		return 0, fmt.Errorf("bad record type: %#x", hdr[0])
+	}
+
+	version := uint16(hdr[1])<<8 | uint16(hdr[2])
+	if version < versionSSL30 || version > versionTLS13 {
+		return 0, fmt.Errorf("bad version: %#x", version)
+	}
+
+	len := int(hdr[3])<<8 | int(hdr[4])
+	return len, nil
+}

--- a/specgen/specgen/main.go
+++ b/specgen/specgen/main.go
@@ -1,0 +1,117 @@
+// Command specgen provides a utility for generating utls.ClientHelloSpecs. This command starts an
+// HTTPS server which responds to every request with a ClientHelloSpec corresponding to the TLS
+// ClientHello the server received. The spec is logged for every request as well. Make a request of
+// the server via web browser to see a ClientHelloSpec for the browser.
+//
+// It is recommended that mkcert be used to generate the keypair for this server. This ensures
+// browsers do not flag and block the page. See https://github.com/FiloSottile/mkcert.
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/getlantern/utls/specgen"
+	"github.com/getlantern/utls/specgen/specgen/hellocap"
+)
+
+const certFileDefaultText = "pre-defined, self-signed cert"
+
+var (
+	addr          = flag.String("addr", "localhost:0", "address to listen on")
+	certFile      = flag.String("cert", certFileDefaultText, "PEM-encoded TLS certificate file")
+	keyFile       = flag.String("key", "", "PEM-encoded TLS key file")
+	packagePrefix = flag.String("prefix", "", "package prefix; see specgen.WriteHelloSpec")
+)
+
+func handleRequest(rw http.ResponseWriter, req *http.Request) {
+	hello, err := hellocap.FromRequest(req)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(rw, "error capturing ClientHello")
+		log.Println("error capturing ClientHello:", err)
+		return
+	}
+
+	buf := new(bytes.Buffer)
+	err = specgen.WriteHelloSpec(buf, hello, *packagePrefix)
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(rw, "error writing ClientHello")
+		log.Println("error writing ClientHello:", err)
+		return
+	}
+
+	ua := req.Header.Get("User-Agent")
+
+	fmt.Fprintln(rw, buf.String())
+	log.Printf("captured ClientHello from %s:\n%s\n", ua, buf.String())
+}
+
+func main() {
+	flag.Parse()
+
+	var cert tls.Certificate
+	var err error
+	if *certFile == certFileDefaultText {
+		cert, err = tls.X509KeyPair([]byte(defaultCertPEM), []byte(defaultKeyPEM))
+	} else {
+		cert, err = tls.LoadX509KeyPair(*certFile, *keyFile)
+	}
+	if err != nil {
+		log.Panicf("failed to load cert: %v", err)
+	}
+
+	s, err := hellocap.NewServer(http.HandlerFunc(handleRequest), *addr, cert)
+	if err != nil {
+		log.Panic(err)
+	}
+
+	log.Println("Listening for incoming connections on", s.Addr())
+
+	if err := s.ListenAndServe(); err != nil {
+		log.Panic(err)
+	}
+}
+
+// A self-signed TLS key pair valid until 2032.
+var (
+	defaultCertPEM = `-----BEGIN CERTIFICATE-----
+MIICyDCCAjGgAwIBAgIUTAmBa1Dd9Hz0pRjoYzi93d+e9GkwDQYJKoZIhvcNAQEL
+BQAwcDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMREwDwYDVQQHDAhTb21lQ2l0
+eTESMBAGA1UECgwJTXlDb21wYW55MRMwEQYDVQQLDApNeURpdmlzaW9uMRgwFgYD
+VQQDDA93d3cuY29tcGFueS5jb20wHhcNMjIxMTA2MjMyNDEzWhcNMzIxMTAzMjMy
+NDEzWjBwMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExETAPBgNVBAcMCFNvbWVD
+aXR5MRIwEAYDVQQKDAlNeUNvbXBhbnkxEzARBgNVBAsMCk15RGl2aXNpb24xGDAW
+BgNVBAMMD3d3dy5jb21wYW55LmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkC
+gYEAoWRAcyBPWAOEIBS7vJIdTKvdRGoY811RYTL1b78i68zIU87Hw03oSL2aw1ol
+gIcFWjupLA8nUI4I6n2ZXpc3tEmf45NPAQEh1V7kxf03CWimbmPw1DHTypYM/Wps
+af9xM+1+jP6ns/h1d8dO4UWdNbMf04+4k0vQtKCshGPniWMCAwEAAaNfMF0wCwYD
+VR0PBAQDAgRwMBMGA1UdJQQMMAoGCCsGAQUFBwMBMBoGA1UdEQQTMBGCCWxvY2Fs
+aG9zdIcEfwAAATAdBgNVHQ4EFgQUEosohEbGBpAeOSVjgf24dql8JlswDQYJKoZI
+hvcNAQELBQADgYEAGywH1HYIL0WaBhLcg5OoYfyWJ20OfTHxLvdMAoM6YVaui1fW
+/Lmf+BTWafx0FW/BLd/ZretaQmvBeUnATz6pZX+kMAZ0AY6Ya/usxpJL1re2W3o9
+nD7qdzdP4OLtYm5xTWOdZR/oj3lZzHNGZmCjs7P/VML4129my1OWAVfINCw=
+-----END CERTIFICATE-----`
+
+	defaultKeyPEM = `-----BEGIN PRIVATE KEY-----
+MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAKFkQHMgT1gDhCAU
+u7ySHUyr3URqGPNdUWEy9W+/IuvMyFPOx8NN6Ei9msNaJYCHBVo7qSwPJ1COCOp9
+mV6XN7RJn+OTTwEBIdVe5MX9Nwlopm5j8NQx08qWDP1qbGn/cTPtfoz+p7P4dXfH
+TuFFnTWzH9OPuJNL0LSgrIRj54ljAgMBAAECgYBHqWgktngEsKr+Q7aIqKhx3u5E
+7oddqFX2PtZUZB5xbWCWNf7lbbZydh4+F80HIOzzgAJCGghu8GJtHI/5PFPy+ORH
+XZvU7eTqt35LM5uuSLisrD/laOPVnCPGrLfmX8U+d00ffwLsiNJ69bCAooia2gzA
+zMVOU9STzQVUdN8sIQJBANbY/vTK8uXDKlmA//eHzvuC5axa+Gmbz8a3z250rs17
+SXUZdIVauwyFWIoaCbZJCd7ow6WSy9WpasZKciXAYUcCQQDATg0+8xbakhLlN9V9
+FzHxNlkQJq6OrHfxNSIEANppI+xmoMlnKDQuoTrubEeKLienPzxzVLqtjPPoTthW
+ZsUFAkAk+Oa3HY27OGC7UlW6NSbLZXU8udLx6ZxR6CPMMEw8lDDJ8/13TWvO9cuM
+yHpPYjZOo+O3RJHLTQJQ6VLHaFnVAkEAs5xy/LeZQd4rLdIfYS135P5I4y/t2640
+fKKOucR+OrNlylkko2fGjULjwup5SxNez/PdJy8dCJnc+b4ii1iDbQJBAKNhQf+H
+s0gTmodJUZ9+7hF6c8D7js2UTc2r79D34nRE3yXmZDU2dJHT2KXbizBPET3OXmtN
+GGAzrM+tNzEmHDc=
+-----END PRIVATE KEY-----`
+)


### PR DESCRIPTION
This package has two major outputs:
- A function for writing out a TLS ClientHello as utls.ClientHelloSpec code.
- A command-line utility for capturing TLS ClientHellos and writing them out as utls.ClientHelloSpec code.

This is the utility I've been using to capture ClientHellos from web browsers.  I fire up my `specgen` utility, listening on localhost, then point browsers at the `specgen` server.